### PR TITLE
Reduce downloading avatar size from GitHub

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,11 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="main.css" />
-    <link rel="icon" type="image/png" href="https://github.com/kachick.png" />
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://github.com/kachick.png?size=48"
+    />
     <title>kachick</title>
   </head>
   <body>


### PR DESCRIPTION
Part of GH-190

![image](https://github.com/user-attachments/assets/cb72528b-2b9f-4abb-9ac1-df11d7f3360b)

![image](https://github.com/user-attachments/assets/5d83797f-396c-418a-8e40-b8242ce5c817)

Actually the downloading size has been reduced